### PR TITLE
Add synonyms for Germany

### DIFF
--- a/app/utils/countrycodes.py
+++ b/app/utils/countrycodes.py
@@ -336,6 +336,7 @@ synonyms = {
     "Reunion"                        : "Réunion",
     "Curacao"                        : "Curaçao",
     "Congo (Brazzaville)"            : "Congo",
+    "Deutschland"                    : "Germany",
     # "Others" has no mapping, i.e. the default val is used
     # "Cruise Ship" has no mapping, i.e. the default val is used
 }


### PR DESCRIPTION
Based on ExpDev07/coronavirus-tracker-api#56, I created a new synonym for countrycode `DE`