### PR TITLE
Added Wrapper for Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,10 @@ programmatically retrieved, re-formatted and stored in the cache for one hour.
 
 These are the available API wrappers created by the community. They are not neccecarily maintained by any of this project's authors or contributors.
 
+### Python
+
+* [COVID19Py by @Kamaropoulos](https://github.com/Kamaropoulos/COVID19Py).
+
 ### Java
 
 * [Coronavirus by @mew](https://github.com/mew/Coronavirus).


### PR DESCRIPTION
Of course the API is made in Python but we also need a way to easily access it without having to worry about what request to send. The added repo is a wrapper that does just that.