### PR TITLE
Ability to exclude timelines from location (https://github.com/ExpDev07/coronavirus-tracker-api/issues/89) + some hotfix with boolean parsing of query params.

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ GET /v2/locations?country_code=US
 
 Include timelines.
 ```http
-GET /v2/locations?country_code=US&timelines=true
+GET /v2/locations?timelines=1
 ```
 
 ### Getting a specific location (includes timelines by default).
@@ -86,26 +86,30 @@ GET /v2/locations/:id
 ```json
 {
   "location": {
-      "id": 39,
-      "country": "Norway",
-      "country_code": "NO",
-      "province": "",
-      "coordinates": { },
-      "latest": { },
-      "timelines": {
-        "confirmed": {
-          "latest": 1463,
-          "timeline": {
-            "2020-03-16T00:00:00Z": 1333,
-            "2020-03-17T00:00:00Z": 1463
-          }
-        },
-        "deaths": { },
-        "recovered": { }
-      }
+    "id": 39,
+    "country": "Norway",
+    "country_code": "NO",
+    "province": "",
+    "coordinates": { },
+    "latest": { },
+    "timelines": {
+      "confirmed": {
+        "latest": 1463,
+        "timeline": {
+          "2020-03-16T00:00:00Z": 1333,
+          "2020-03-17T00:00:00Z": 1463
+        }
+      },
+      "deaths": { },
+      "recovered": { }
     }
   }
 }
+```
+
+Exclude timelines.
+```http
+GET /v2/locations?timelines=0
 ```
 
 ## Data

--- a/app/routes/v2/locations.py
+++ b/app/routes/v2/locations.py
@@ -1,10 +1,11 @@
+from distutils.util import strtobool
 from flask import jsonify, request, current_app as app
 from ...services import jhu
 
 @app.route('/v2/locations')
 def locations():
     # Query parameters.
-    timelines    = request.args.get('timelines', type=bool, default=False)
+    timelines    = strtobool(request.args.get('timelines', default='0'))
     country_code = request.args.get('country_code', type=str)
 
     # Retrieve all the locations.
@@ -23,7 +24,10 @@ def locations():
 
 @app.route('/v2/locations/<int:id>')
 def location(id):
-    # Serialize the location with timelines.
+    # Query parameters.
+    timelines = strtobool(request.args.get('timelines', default='1'))
+
+    # Return serialized location.
     return jsonify({
-        'location': jhu.get(id).serialize(True)
+        'location': jhu.get(id).serialize(timelines)
     })


### PR DESCRIPTION
This introduces the ability to exclude timelines from ``/v2/locations/:id`` (https://github.com/ExpDev07/coronavirus-tracker-api/issues/89) by adding  ``?timelines=0`` or ``?timelines=false``. It will still show timelines by default so not to break existing apps.

An issue where all values (even false or 0) were regarded as true when parsed to a boolean in the code.