### PR TITLE
Add query by country in /v2/country

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# OSX stuff
+.DS_Store

--- a/app/routes/__init__.py
+++ b/app/routes/__init__.py
@@ -5,7 +5,7 @@ api_v1 = Blueprint('api_v1', __name__, url_prefix='')
 api_v2 = Blueprint('api_v2', __name__, url_prefix='/v2')
 
 # API version 2.
-from .v2 import locations, latest
+from .v2 import locations, latest, country
 
 # API version 1.
 from .v1 import confirmed, deaths, recovered, all

--- a/app/routes/v2/country.py
+++ b/app/routes/v2/country.py
@@ -1,0 +1,38 @@
+from flask import jsonify, request
+from ...routes import api_v2 as api
+from ...services import jhu
+
+@api.route('/country')
+def country():
+
+    # Retrieve all the locations.
+    locations = jhu.get_all()
+
+    # accepts either country or country_code as a parameter, but only one is required
+    country_code = request.args.get('country_code', type=str)
+    country = request.args.get('country', type=str)
+
+    # sort by given country or country_code. Country_code will always override country
+    if country_code:
+        country_locations = list(filter(lambda location: location.country_code == country_code.upper(), locations))
+    elif country:
+        country_locations = list(filter(lambda location: location.country.lower() == country.lower(), locations))
+
+    # serialize location objects
+    country_locations = [location.serialize() for location in country_locations]
+
+    # check for errors in query
+    if not country_locations:
+        return jsonify({'error': 'parameter country_code or country required'})
+
+    # return as a singe dictionary
+    return jsonify({
+        'country_code': country_locations[0]['country_code'],
+        'country'     : country_locations[0]['country'],
+
+        'latest': {
+            'confirmed': sum(location['latest']['confirmed'] for location in country_locations),
+            'deaths'   : sum(location['latest']['deaths'] for location in country_locations),
+            'recovered': sum(location['latest']['recovered'] for location in country_locations),
+        }
+    })

--- a/coronavirus-tracker-api-swagger.yaml
+++ b/coronavirus-tracker-api-swagger.yaml
@@ -86,6 +86,43 @@ paths:
                 $ref: '#/definitions/Location'
         '404':
           description: Location not found
+  /country:
+    get:
+      summary: Latest Corona stats by country
+      operationId: latest
+      produces:
+        - application/json
+            parameters:
+        - name: country_code
+          in: query
+          description: "ISO alpha 2 country code. https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2"
+          required: true
+          type: string
+          x-example: US
+        - name: country
+          in: query
+          description: "Country to search by"
+          required: true
+          type: string
+          x-example: "China"
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            type: object
+            properties:
+              latest:
+                type: object
+                properties:
+                  confirmed:
+                    type: number
+                    example: 214910
+                  deaths:
+                    type: number
+                    example: 8733
+                  recovered:
+                    type: number
+                    example: 83207
 definitions:
   Location:
     type: object


### PR DESCRIPTION
This adds a new endpoint to /v2/ where users can query for information by country. Example: /v2/country?country=Ireland returns {"country":"Ireland","country_code":"IE","latest":{"confirmed":683,"deaths":3,"recovered":5}}