### PR TITLE
hotfix for location mismatch data

### DIFF
--- a/app/services/location/jhu.py
+++ b/app/services/location/jhu.py
@@ -116,7 +116,7 @@ def get_locations():
     # Get all of the data categories locations.
     confirmed = get_category('confirmed')['locations']
     deaths    = get_category('deaths')['locations']
-    recovered = get_category('recovered')['locations']
+    # recovered = get_category('recovered')['locations']
 
     # Final locations to return.
     locations = []
@@ -127,7 +127,7 @@ def get_locations():
         timelines = {
             'confirmed' : confirmed[index]['history'],
             'deaths'    : deaths[index]['history'],
-            'recovered' : recovered[index]['history'],
+            # 'recovered' : recovered[index]['history'],
         }
 
         # Grab coordinates.
@@ -151,7 +151,7 @@ def get_locations():
             {
                 'confirmed': Timeline({ datetime.strptime(date, '%m/%d/%y').isoformat() + 'Z': amount for date, amount in timelines['confirmed'].items() }),
                 'deaths'   : Timeline({ datetime.strptime(date, '%m/%d/%y').isoformat() + 'Z': amount for date, amount in timelines['deaths'].items() }),
-                'recovered': Timeline({ datetime.strptime(date, '%m/%d/%y').isoformat() + 'Z': amount for date, amount in timelines['recovered'].items() })
+                'recovered': Timeline({})
             }
         ))
     

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -86,7 +86,7 @@ class FlaskRoutesTest(unittest.TestCase):
             'latest': {
                 'confirmed': 1940,
                 'deaths': 1940,
-                'recovered': 1940
+                'recovered': 0
             }
         }
 


### PR DESCRIPTION
Due to how JHU has restructured their files, indexes have messed up in regards to recovery numbers, leading to countries pointing to wrong data. This drops support for recovery numbers for JHU source completely and it will display 0.

Related: https://github.com/ExpDev07/coronavirus-tracker-api/pull/156.