### PR TITLE
Fix Docker ports & Gunicorn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,14 @@
 FROM tiangolo/uvicorn-gunicorn-fastapi:python3.7
 
-# ENVS RECOMENDATIONS
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
-
-# PREPARE FOLDER
-WORKDIR /api
+ENV VARIABLE_NAME APP
 
 # COPY DEPENDENCIES
 COPY requirements.txt ./
 
+# COPY PROJECT
+COPY ./app /app/app
+
 # INSTALL DEPENDENCIES
 RUN pip install --no-cache-dir -r  requirements.txt
 
-# COPY PROJECT
-COPY . /api/
-
-CMD ["uvicorn", "--host", "0.0.0.0", "app.main:APP"]
+EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -413,8 +413,17 @@ And don't despair if don't get the python setup working on the first try. No one
 
 ## Running / Development
 
+For a live reloading on code changes.
+
 * `pipenv run dev`
-* Visit your app at [http://localhost:8000](http://localhost:8000).
+
+Without live reloading.
+
+* `pipenv run start`
+
+Visit your app at [http://localhost:8000](http://localhost:8000).
+
+Alternatively run our API with Docker.
 
 ### Running Tests
 > [pytest](https://docs.pytest.org/en/latest/)
@@ -446,7 +455,22 @@ invoke generate-reqs
 
 [Pipfile.lock](./Pipfile.lock) will be automatically updated during `pipenv install`.
 
-### Building
+### Docker
+
+Our Docker image is based on [tiangolo/uvicorn-gunicorn-fastapi/](https://hub.docker.com/r/tiangolo/uvicorn-gunicorn-fastapi/).
+
+```bash
+invoke docker --build
+```
+
+Run with `docker run` or `docker-compose`
+
+### Invoke
+
+Additional developer commands can be run by calling them with the [python `invoke` task runner](http://www.pyinvoke.org/).
+```bash
+invoke --list
+```
 
 ### Deploying
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: "3.7"
 
 services:
   api:
@@ -8,6 +8,6 @@ services:
     volumes:
       - .:/api
     ports:
-      - "8000:8000"
+      - "80:80"
     stdin_open: true
     tty: true

--- a/tasks.py
+++ b/tasks.py
@@ -9,6 +9,8 @@ Available commands
   invoke sort
   invoke check
 """
+import random
+
 import invoke
 
 TARGETS_DESCRIPTION = "Paths/directories to format. [default: . ]"
@@ -71,3 +73,17 @@ def generate_reqs(ctx):
     """Generate requirements.txt"""
     reqs = ["pipenv lock -r > requirements.txt", "pipenv lock -r --dev > requirements-dev.txt"]
     [ctx.run(req) for req in reqs]
+
+
+@invoke.task
+def docker(
+    ctx, build=False, run=False, tag="covid-tracker-api:latest", port=80, name=f"covid-api-{random.randint(0,999)}"
+):  # pylint: disable=too-many-arguments
+    """Build and run docker container."""
+    if not any([build, run]):
+        raise invoke.Exit(message="Specify either --build or --run", code=1)
+    if build:
+        docker_cmds = ["build", "."]
+    else:
+        docker_cmds = ["run", "-p", str(port), "--name", name]
+    ctx.run(" ".join(["docker", *docker_cmds, "-t", tag]))

--- a/tasks.py
+++ b/tasks.py
@@ -76,14 +76,12 @@ def generate_reqs(ctx):
 
 
 @invoke.task
-def docker(
-    ctx, build=False, run=False, tag="covid-tracker-api:latest", port=80, name=f"covid-api-{random.randint(0,999)}"
-):  # pylint: disable=too-many-arguments
+def docker(ctx, build=False, run=False, tag="covid-tracker-api:latest", name=f"covid-api-{random.randint(0,999)}"):
     """Build and run docker container."""
     if not any([build, run]):
         raise invoke.Exit(message="Specify either --build or --run", code=1)
     if build:
         docker_cmds = ["build", "."]
     else:
-        docker_cmds = ["run", "-p", str(port), "--name", name]
+        docker_cmds = ["run", "--publish", "80", "--name", name]
     ctx.run(" ".join(["docker", *docker_cmds, "-t", tag]))


### PR DESCRIPTION
Our current dockerfile was using the [tiangolo/uvicorn-gunicorn-fastapi
](https://fastapi.tiangolo.com/deployment/#tiangolouvicorn-gunicorn-fastapi) docker image, but was configured to run as `uvicorn` directly.

* Updated Dockerfile and docker-compose to work with `gunicorn` (running `uvicorn` workers).
* Publish the correct port (`80`)
* Added `invoke docker --build` to easily build a docker image.
* Added `invoke docker --run` to start the container and "publish" the correct port

fixes #269 

After building and running the container, the API should be reachable locally at
http://192.168.99.100/ 

![image](https://user-images.githubusercontent.com/13108583/79032810-4f4d1d80-7b77-11ea-96f3-66b19cb5e283.png)

## Next steps
- [x] Update docs
- [ ] It might be helpful to have [another Dockerfile](https://fastapi.tiangolo.com/deployment/#raspberry-pi-and-other-architectures) that runs `uvicorn` directly.
- [ ] replace/update the[ `prestart.sh` script](https://github.com/tiangolo/uvicorn-gunicorn-fastapi-docker#custom-appprestartsh)
