### PR TITLE
reduce TTL cache maxsize

### DIFF
--- a/app/services/location/jhu.py
+++ b/app/services/location/jhu.py
@@ -46,10 +46,10 @@ BASE_URL = (
 )
 
 
-@cached(cache=TTLCache(maxsize=1024, ttl=1800))
+@cached(cache=TTLCache(maxsize=128, ttl=1800))
 async def get_category(category):
     """
-    Retrieves the data for the provided category. The data is cached for 1 hour.
+    Retrieves the data for the provided category. The data is cached for 30 minutes locally, 1 hour via shared Redis.
 
     :returns: The data for category.
     :rtype: dict

--- a/app/services/location/nyt.py
+++ b/app/services/location/nyt.py
@@ -66,7 +66,7 @@ def get_grouped_locations_dict(data):
     return grouped_locations
 
 
-@cached(cache=TTLCache(maxsize=1024, ttl=3600))
+@cached(cache=TTLCache(maxsize=128, ttl=3600))
 async def get_locations():
     """
     Returns a list containing parsed NYT data by US county. The data is cached for 1 hour.


### PR DESCRIPTION
I believe the cache size can be much lower still. 
AFIAK the `maxsize` isn't the "size" of the cache so much as it is the number of recent calls to the function to save. `get_category()` only has 3 possible parameters it receives. So my understanding is as long as the max size is greater than those 3 different function calls everything should work fine.

As per the standard lib `lru` cache which I believe `cachetools` is based on.

https://docs.python.org/3/library/functools.html#functools.lru_cache
>Decorator to wrap a function with a memoizing callable that saves up to the maxsize most recent calls.

## Future steps
* investigate and further optimize the cache settings to reduce memory usage