### PR TITLE
Aggregate Pattern for DataSource

### DIFF
--- a/app/data/__init__.py
+++ b/app/data/__init__.py
@@ -2,20 +2,25 @@
 from ..services.location.csbs import CSBSLocationService
 from ..services.location.jhu import JhuLocationService
 from ..services.location.nyt import NYTLocationService
+from ..services.location import LocationService
 
-# Mapping of services to data-sources.
-DATA_SOURCES = {
-    "jhu": JhuLocationService(),
-    "csbs": CSBSLocationService(),
-    "nyt": NYTLocationService(),
-}
+class DataSource:
+    __DATA_SOURCES = {}
 
+    def __init__(self):
+        self.__DATA_SOURCES['jhu'] = JhuLocationService()
+        self.__DATA_SOURCES['csbs'] = CSBSLocationService()
+        self.__DATA_SOURCES['nyt'] = NYTLocationService()
 
-def data_source(source):
-    """
-    Retrieves the provided data-source service.
+    # Mapping of services to data-sources.
+    @classmethod
+    def get_data_source(self, source: str) -> LocationService:
+        return self.__DATA_SOURCES.get(source.lower())
 
-    :returns: The service.
-    :rtype: LocationService
-    """
-    return DATA_SOURCES.get(source.lower())
+    @classmethod
+    def add_data_source(self, source: str, reference_to_source: LocationService) -> None:
+        self.__DATA_SOURCES[source] = reference_to_source
+    
+    @classmethod
+    def get_all_sources(self) -> dict:
+        return self.__DATA_SOURCES

--- a/app/main.py
+++ b/app/main.py
@@ -14,7 +14,7 @@ from scout_apm.async_.starlette import ScoutMiddleware
 from sentry_sdk.integrations.asgi import SentryAsgiMiddleware
 
 from .config import get_settings
-from .data import data_source
+from .data import DataSource
 from .routers import V1, V2
 from .utils.httputils import setup_client_session, teardown_client_session
 
@@ -74,7 +74,9 @@ async def add_datasource(request: Request, call_next):
     Attach the data source to the request.state.
     """
     # Retrieve the datas ource from query param.
-    source = data_source(request.query_params.get("source", default="jhu"))
+    source = DataSource()
+    source.get_data_source(request.query_params.get("source", default = "jhu"))
+    
 
     # Abort with 404 if source cannot be found.
     if not source:

--- a/app/routers/v2.py
+++ b/app/routers/v2.py
@@ -3,7 +3,7 @@ import enum
 
 from fastapi import APIRouter, HTTPException, Request
 
-from ..data import DATA_SOURCES
+from ..data import DataSource
 from ..models import LatestResponse, LocationResponse, LocationsResponse
 
 V2 = APIRouter()
@@ -26,7 +26,7 @@ async def get_latest(
     """
     Getting latest amount of total confirmed cases, deaths, and recoveries.
     """
-    locations = await request.state.source.get_all()
+    locations = await request.state.source.get_all_sources()[source].get_all()
     return {
         "latest": {
             "confirmed": sum(map(lambda location: location.confirmed, locations)),
@@ -57,7 +57,7 @@ async def get_locations(
     params.pop("timelines", None)
 
     # Retrieve all the locations.
-    locations = await request.state.source.get_all()
+    locations = await request.state.source.get_all_sources()[source].get_all()
 
     # Attempt to filter out locations with properties matching the provided query params.
     for key, value in params.items():
@@ -98,7 +98,7 @@ async def get_location_by_id(
     """
     Getting specific location by id.
     """
-    location = await request.state.source.get(id)
+    location = await request.state.source.get_all_sources()[source].get(id)
     return {"location": location.serialize(timelines)}
 
 
@@ -107,4 +107,5 @@ async def sources():
     """
     Retrieves a list of data-sources that are availble to use.
     """
-    return {"sources": list(DATA_SOURCES.keys())}
+    data_source = DataSource()
+    return {"sources": list(data_source.get_all_sources().keys())}


### PR DESCRIPTION
Modified Files:
- 'app/data/__init.py'
- 'main.py'
- 'app/routers/v2.py'


### _Modified the file 'app/data/__init__.py' to implement the AGGREGATION pattern._

Replaces the original way of accessing the _DATA_SOURCES_ dictionary. Rather than having the dictionary be a globally accessible object the dictionary is now only accessible through an instance of the class 'DataSource' which acts as the root in the boundary. 

The boundary of 'DataSource' would thus include the __DATA_SOURCE dictionary which is now encapsulated, which holds references to the services (NYT, CSBS, Jhu).

As such the dictionary is now accessible through a getter `def get_data_source(self, source: str) -> LocationService:`
And the dictionary can also be appended through a setter `def add_data_source(self, source: str, reference_to_source: LocationService) -> None:`

Also to ensure consistency in functionality with how sources are accessed in each request in 'v2.py' the class (DataSource) implements a `def get_all_sources(self) -> dict:` method which returns the dictionary. This prevents breaking any functionality in 'v2.py'.

For example instead of an endpoint accessing a source via
`locations = await request.state.source.get_all() `

It is now accessed with a minor change of
`locations = await request.state.source.get_all_sources()[source].get_all()`


Minor changes in 'main.py' are implemented in order to set the default source.
Before:    `source = data_source(request.query_params.get("source", default="jhu"))`
After: `source = DataSource() `
    `source.get_data_source(request.query_params.get("source", default = "jhu"))`

Again, this implementation encourages aggregation which in turn enforces the objects inside the boundary to be only accessible through the root. This ensures invariants such as the fact that only one source should be returned through the getter.
