### PR TITLE
Apply aggregation pattern to data source URLs in services/location

### DIFF
--- a/app/services/location/csbs.py
+++ b/app/services/location/csbs.py
@@ -10,6 +10,7 @@ from ...caches import check_cache, load_cache
 from ...coordinates import Coordinates
 from ...location.csbs import CSBSLocation
 from ...utils import httputils
+from ...utils.data_urls import DataURLs
 from . import LocationService
 
 LOGGER = logging.getLogger("services.location.csbs")
@@ -31,10 +32,6 @@ class CSBSLocationService(LocationService):
         return locations[loc_id]
 
 
-# Base URL for fetching data
-BASE_URL = "https://facts.csbs.org/covid-19/covid19_county.csv"
-
-
 @cached(cache=TTLCache(maxsize=1, ttl=1800))
 async def get_locations():
     """
@@ -52,7 +49,7 @@ async def get_locations():
         locations = cache_results
     else:
         LOGGER.info(f"{data_id} shared cache empty")
-        async with httputils.CLIENT_SESSION.get(BASE_URL) as response:
+        async with httputils.CLIENT_SESSION.get(DataURLs.CSBS) as response:
             text = await response.text()
 
         LOGGER.debug(f"{data_id} Data received")

--- a/app/services/location/jhu.py
+++ b/app/services/location/jhu.py
@@ -15,6 +15,7 @@ from ...models import Timeline
 from ...utils import countries
 from ...utils import date as date_util
 from ...utils import httputils
+from ...utils.data_urls import DataURLs
 from . import LocationService
 
 LOGGER = logging.getLogger("services.location.jhu")
@@ -40,10 +41,6 @@ class JhuLocationService(LocationService):
 # ---------------------------------------------------------------
 
 
-# Base URL for fetching category.
-BASE_URL = "https://raw.githubusercontent.com/CSSEGISandData/2019-nCoV/master/csse_covid_19_data/csse_covid_19_time_series/"
-
-
 @cached(cache=TTLCache(maxsize=4, ttl=1800))
 async def get_category(category):
     """
@@ -64,7 +61,7 @@ async def get_category(category):
     else:
         LOGGER.info(f"{data_id} shared cache empty")
         # URL to request data from.
-        url = BASE_URL + "time_series_covid19_%s_global.csv" % category
+        url = DataURLs.JHU + "time_series_covid19_%s_global.csv" % category
 
         # Request the data
         LOGGER.info(f"{data_id} Requesting data...")

--- a/app/services/location/nyt.py
+++ b/app/services/location/nyt.py
@@ -11,6 +11,7 @@ from ...coordinates import Coordinates
 from ...location.nyt import NYTLocation
 from ...models import Timeline
 from ...utils import httputils
+from ...utils.data_urls import DataURLs
 from . import LocationService
 
 LOGGER = logging.getLogger("services.location.nyt")
@@ -33,10 +34,6 @@ class NYTLocationService(LocationService):
 
 
 # ---------------------------------------------------------------
-
-
-# Base URL for fetching category.
-BASE_URL = "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-counties.csv"
 
 
 def get_grouped_locations_dict(data):
@@ -85,7 +82,7 @@ async def get_locations():
         locations = cache_results
     else:
         LOGGER.info(f"{data_id} shared cache empty")
-        async with httputils.CLIENT_SESSION.get(BASE_URL) as response:
+        async with httputils.CLIENT_SESSION.get(DataURLs.NYT) as response:
             text = await response.text()
 
         LOGGER.debug(f"{data_id} Data received")

--- a/app/utils/data_urls.py
+++ b/app/utils/data_urls.py
@@ -1,0 +1,13 @@
+"""app.utils.data_urls.py"""
+
+import enum
+
+
+class DataURLs(str, enum.Enum):
+    """
+    URLs available for retrieving data from each possible source.
+    """
+
+    JHU = "https://raw.githubusercontent.com/CSSEGISandData/2019-nCoV/master/csse_covid_19_data/csse_covid_19_time_series/"
+    CSBS = "https://facts.csbs.org/covid-19/covid19_county.csv"
+    NYT = "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-counties.csv"


### PR DESCRIPTION
### What does this PR do? 

This PR creates a new util file, `app/utils/data_urls.py`, which serves as the root for a new aggregate pattern. For this aggregate, the DataURLs class in the new util file serves as the aggregate root, through which the different URLs to access each data source (which form the boundary) can be retrieved. I made these changes by first creating the new util file, then removing the local `BASE_URL` variables that each location service sets and instead referring to the appropriate URL contained within DataURLs in each of the location service files (csbs.py, jhu.py, and nyt.py). It was also necessary to add an import to the new util file within each of these location service files. 

### Why make these changes? 

Since each of the three location services "have a" BASE_URL, it seems intuitive that applying an aggregate pattern here would help simplify the domain model, specifically for each of the location services. In the new aggregate, DataURLs is the publicly visible root which each of the location services have a "has a" relationship with, instead of with the individual data source URLs. These URLs instead make up the boundary of the aggregate.  Making these data source URLs accessible through enums makes sense, though an alternative would be to store them in a dictionary, as in pull request #363. I chose the name of DataURLs for the aggregate's root because it is fairly descriptive of what the purpose of this aggregate is: to contain the individual URLs to access each data source.