### PR TITLE
creational pattern patch

### DIFF
--- a/app/data/__init__.py
+++ b/app/data/__init__.py
@@ -3,14 +3,6 @@ from ..services.location.csbs import CSBSLocationService
 from ..services.location.jhu import JhuLocationService
 from ..services.location.nyt import NYTLocationService
 
-# Mapping of services to data-sources.
-DATA_SOURCES = {
-    "jhu": JhuLocationService(),
-    "csbs": CSBSLocationService(),
-    "nyt": NYTLocationService(),
-}
-
-
 def data_source(source):
     """
     Retrieves the provided data-source service.
@@ -18,4 +10,13 @@ def data_source(source):
     :returns: The service.
     :rtype: LocationService
     """
-    return DATA_SOURCES.get(source.lower())
+    s = source.lower()
+    # return the singleton instance of the required service
+    if s == 'jhu': 
+        return JhuLocationService.getInstance()
+    elif s == 'csbs': 
+        return CSBSLocationService.getInstance()
+    elif s == 'nyt': 
+        return NYTLocationService.getInstance()
+    else:
+        return None

--- a/app/data/__init__.py
+++ b/app/data/__init__.py
@@ -3,6 +3,8 @@ from ..services.location.csbs import CSBSLocationService
 from ..services.location.jhu import JhuLocationService
 from ..services.location.nyt import NYTLocationService
 
+DATA_SOURCES =  ['jhu', 'csbs', 'nyt']
+
 def data_source(source):
     """
     Retrieves the provided data-source service.
@@ -11,6 +13,8 @@ def data_source(source):
     :rtype: LocationService
     """
     s = source.lower()
+    if s not in DATA_SOURCES:
+        return None
     # return the singleton instance of the required service
     if s == 'jhu': 
         return JhuLocationService.getInstance()
@@ -18,5 +22,3 @@ def data_source(source):
         return CSBSLocationService.getInstance()
     elif s == 'nyt': 
         return NYTLocationService.getInstance()
-    else:
-        return None

--- a/app/routers/v2.py
+++ b/app/routers/v2.py
@@ -107,4 +107,4 @@ async def sources():
     """
     Retrieves a list of data-sources that are availble to use.
     """
-    return {"sources": list(DATA_SOURCES.keys())}
+    return {"sources": DATA_SOURCES)}

--- a/app/services/location/__init__.py
+++ b/app/services/location/__init__.py
@@ -7,6 +7,10 @@ class LocationService(ABC):
     Service for retrieving locations.
     """
 
+    # this class variable will store the singleton instance for 
+    # the LocationService instance from the child class
+    __instance__ = None
+
     @abstractmethod
     async def get_all(self):
         """
@@ -26,3 +30,13 @@ class LocationService(ABC):
         :rtype: Location
         """
         raise NotImplementedError
+    
+    @classmethod
+    def getInstance(cls):
+        # singleton pattern
+        if cls.__instance__ is None:
+            # instantiate new object from the class (note that we are 
+            # expecting 0 parameters for the constructor. if parameters 
+            # needed this method should be overridden by the subclass)
+            cls.__instance__ = cls()
+        return cls.__instance__


### PR DESCRIPTION
The location services associated with csbs, jhu and nyt require only one instance of each to perform the necessary operation. Therefore in order to avoid wasting memory we would create only one instance of each and access it using the singleton pattern. For this end I created a class-level variable `__instance__` and a method `getInstance` in the parent class LocationService to implement the singleton pattern. And then updated data.__init__.py module to use the getInstance to retrieve and return the relevant LocationService instance.