### PR TITLE
Structural_Adapter_Design_Pattern

### DIFF
--- a/app/location/__init__.py
+++ b/app/location/__init__.py
@@ -3,9 +3,18 @@ from ..coordinates import Coordinates
 from ..utils import countries
 from ..utils.populations import country_population
 
+from abc import abstractmethod, ABCMeta
+
+class ILocation(metaclass=ABCMeta):
+
+    @abstractmethod
+    def serialize():
+        """
+        Serializes the location into a dict.
+        """
 
 # pylint: disable=redefined-builtin,invalid-name
-class Location:  # pylint: disable=too-many-instance-attributes
+class Location(ILocation):  # pylint: disable=too-many-instance-attributes
     """
     A location in the world affected by the coronavirus.
     """
@@ -72,6 +81,7 @@ class Location:  # pylint: disable=too-many-instance-attributes
                 "recovered": self.recovered,
             },
         }
+
 
 
 class TimelinedLocation(Location):

--- a/app/location/__init__.py
+++ b/app/location/__init__.py
@@ -82,7 +82,81 @@ class Location(ILocation):  # pylint: disable=too-many-instance-attributes
             },
         }
 
+# pylint: disable=redefined-builtin,invalid-name
+class LocationAdapter(Location):  # pylint: disable=too-many-instance-attributes
+    """
+    A location in the world affected by the coronavirus.
+    """
 
+    def __init__(
+        self, id, country, province, coordinates, last_updated, confirmed, deaths, recovered,
+    ):  # pylint: disable=too-many-arguments
+        # General info.
+        self.id = id
+        self.country = country.strip()
+        self.province = province.strip()
+        self.coordinates = coordinates
+
+        # Last update.
+        self.last_updated = last_updated
+
+        # Statistics.
+        self.confirmed = confirmed
+        self.deaths = deaths
+        self.recovered = recovered
+
+    @property
+    def country_code(self):
+        """
+        Gets the alpha-2 code represention of the country. Returns 'XX' if none is found.
+
+        :returns: The country code.
+        :rtype: str
+        """
+        return (countries.country_code(self.country) or countries.DEFAULT_COUNTRY_CODE).upper()
+
+    @property
+    def country_population(self):
+        """
+        Gets the population of this location.
+
+        :returns: The population.
+        :rtype: int
+        """
+        return country_population(self.country_code)
+
+    def serialize(self):
+        """
+        Serializes the location into a dict.
+
+        :returns: The serialized location.
+        :rtype: dict
+        """
+        serialized =  {
+            # General info.
+            "id": self.id,
+            "country": self.country,
+            "country_code": self.country_code,
+            "country_population": self.country_population,
+            "province": self.province,
+            # Coordinates.
+            "coordinates": self.coordinates.serialize(),
+            # Last updated.
+            "last_updated": self.last_updated,
+            # Latest data (statistics).
+            "latest": {
+                "confirmed": self.confirmed,
+                "deaths": self.deaths,
+                "recovered": self.recovered,
+            },
+        }
+
+        # Update with new fields.
+        serialized.update(
+            {"state": self.province, "county": self.county,}
+        )
+
+        return serialized
 
 class TimelinedLocation(Location):
     """

--- a/app/location/csbs.py
+++ b/app/location/csbs.py
@@ -1,8 +1,8 @@
 """app.locations.csbs.py"""
-from . import Location
+from . import LocationAdapter
 
 
-class CSBSLocation(Location):
+class CSBSLocation(LocationAdapter):
     """
     A CSBS (county) location.
     """
@@ -33,11 +33,6 @@ class CSBSLocation(Location):
         :rtype: dict
         """
         serialized = super().serialize()
-
-        # Update with new fields.
-        serialized.update(
-            {"state": self.state, "county": self.county,}
-        )
 
         # Return the serialized location.
         return serialized

--- a/app/utils/baseurls.py
+++ b/app/utils/baseurls.py
@@ -1,0 +1,10 @@
+import enum
+
+class BaseUrl(str, enum.Enum):
+    """
+    A base url available for retrieving data.
+    """
+
+    JHU = "https://raw.githubusercontent.com/CSSEGISandData/2019-nCoV/master/csse_covid_19_data/csse_covid_19_time_series/"
+    CSBS = "https://facts.csbs.org/covid-19/covid19_county.csv"
+    NYT = "https://raw.githubusercontent.com/nytimes/covid-19-data/master/us-counties.csv"


### PR DESCRIPTION
Why I did it? 
Within the Structural Patterns I decided to use Adapter Design Method to allow objects with incompatible interfaces to collaborate

How I did it?
I Created a Replica of location class because serializer function has different behavior for CSBS LOCATION Class thus we created a class Location adapter "making changes in "init_py"
and using the Csbs.py i had to update serializer response and removed it from csbslocation class.