### PR TITLE
Creational pattern on data source

### DIFF
--- a/app/data/__init__.py
+++ b/app/data/__init__.py
@@ -1,15 +1,32 @@
 """app.data"""
+from ..services.location import LocationService
 from ..services.location.csbs import CSBSLocationService
 from ..services.location.jhu import JhuLocationService
 from ..services.location.nyt import NYTLocationService
 
-# Mapping of services to data-sources.
-DATA_SOURCES = {
-    "jhu": JhuLocationService(),
-    "csbs": CSBSLocationService(),
-    "nyt": NYTLocationService(),
-}
+class dataSourceFactory():
+    def getDataSource():
+        return LocationService()
 
+class JhuFactory(dataSourceFactory):
+    def getDataSource():
+        return JhuLocationService()
+
+class CSBSFactory(dataSourceFactory):
+    def getDataSource():
+        return CSBSLocationService()
+
+class NYTFactory(dataSourceFactory):
+    def getDataSource():
+        return NYTLcationService()
+
+
+# Mapping of factories to data-sources.
+DATA_SOURCES = {
+    "jhu": JhuFactory(),
+    "csbs": CSBSFactory(),
+    "nyt": NYTFactory(),
+}
 
 def data_source(source):
     """
@@ -18,4 +35,4 @@ def data_source(source):
     :returns: The service.
     :rtype: LocationService
     """
-    return DATA_SOURCES.get(source.lower())
+    return DATA_SOURCES.get(source.lower()).getDataSource()

--- a/app/data/__init__.py
+++ b/app/data/__init__.py
@@ -18,7 +18,7 @@ class CSBSFactory(dataSourceFactory):
 
 class NYTFactory(dataSourceFactory):
     def getDataSource():
-        return NYTLcationService()
+        return NYTLocationService()
 
 
 # Mapping of factories to data-sources.

--- a/app/data/__init__.py
+++ b/app/data/__init__.py
@@ -1,31 +1,102 @@
 """app.data"""
-from ..services.location import LocationService
+from abc import ABC, abstractmethod
 from ..services.location.csbs import CSBSLocationService
 from ..services.location.jhu import JhuLocationService
 from ..services.location.nyt import NYTLocationService
 
-class dataSourceFactory():
-    def getDataSource():
-        return LocationService()
+class DataSourceFactory(ABC):
+    def __init__(self):
+        pass
+   
+    @abstractmethod 
+    def getInstance():
+        pass
 
-class JhuFactory(dataSourceFactory):
-    def getDataSource():
-        return JhuLocationService()
+    @abstractmethod
+    def getService():
+        pass
 
-class CSBSFactory(dataSourceFactory):
-    def getDataSource():
-        return CSBSLocationService()
+class JhuFactory(DataSourceFactory):
+    __instance = None
+    __service = None
 
-class NYTFactory(dataSourceFactory):
-    def getDataSource():
-        return NYTLocationService()
+    def __init__(self):
+        if JhuFactory.__instance != None:
+            raise Exception("Factory is singleton!")
+        elif JhuFactory.__service != None:
+            raise Exception("Service is singleton!")
+        else:
+            JhuFactory.__instance = self
+            JhuFactory.__service = JhuLocationService()
+        
+    @staticmethod 
+    def getInstance():
+      if JhuFactory.__instance == None:
+         JhuFactory()
+      return JhuFactory.__instance
+        
+    @staticmethod 
+    def getService():
+      if JhuFactory.__service == None:
+         JhuFactory()
+      return JhuFactory.__service
+
+class CSBSFactory(DataSourceFactory):
+    __instance = None
+    __service = None
+
+    def __init__(self):
+        if CSBSFactory.__instance != None:
+            raise Exception("Factory is singleton!")
+        elif CSBSFactory.__service != None:
+            raise Exception("Service is singleton!")
+        else:
+            CSBSFactory.__instance = self
+            CSBSFactory.__service = CSBSLocationService()
+   
+    @staticmethod 
+    def getInstance():
+      if CSBSFactory.__instance == None:
+         CSBSFactory()
+      return CSBSFactory.__instance
+
+    @staticmethod 
+    def getService():
+      if CSBSFactory.__service == None:
+         CSBSFactory()
+      return CSBSFactory.__service
+
+class NYTFactory(DataSourceFactory):
+    __instance = None
+    __service = None
+
+    def __init__(self):
+        if NYTFactory.__instance != None:
+            raise Exception("Factory is singleton!")
+        elif NYTFactory.__service != None:
+            raise Exception("Service is singleton!")
+        else:
+            NYTFactory.__instance = self
+            NYTFactory.__service = NYTLocationService()
+   
+    @staticmethod 
+    def getInstance():
+      if NYTFactory.__instance == None:
+         NYTFactory()
+      return NYTFactory.__instance
+
+    @staticmethod 
+    def getService():
+      if NYTFactory.__service == None:
+         NYTFactory()
+      return NYTFactory.__service
 
 
 # Mapping of factories to data-sources.
 DATA_SOURCES = {
-    "jhu": JhuFactory(),
-    "csbs": CSBSFactory(),
-    "nyt": NYTFactory(),
+    "jhu": JhuFactory.getInstance(),
+    "csbs": CSBSFactory.getInstance(),
+    "nyt": NYTFactory.getInstance(),
 }
 
 def data_source(source):
@@ -35,4 +106,4 @@ def data_source(source):
     :returns: The service.
     :rtype: LocationService
     """
-    return DATA_SOURCES.get(source.lower()).getDataSource()
+    return DATA_SOURCES.get(source.lower()).getService()


### PR DESCRIPTION
The factory and singleton patterns were introduced to the data source to make it easier to modify the code when changes need to be made to the data source and to reduce memory usage.

To do this, I first created a factory called DataSourceFactory, including getInstance and getService methods. After that, I created subclasses of the factory for each of the three data sources. Then, I make the factory a singleton by using the getInstance method, which creates a new object the first time it is called and stores it in a static variable.  The method returns the instance each time it is called after that. In addition, I made the Service a singleton by using getService, which is implemented in the same way as getInstance.